### PR TITLE
Get additional info when locking job

### DIFF
--- a/que.go
+++ b/que.go
@@ -340,7 +340,7 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			&j.Type,
 			&j.Args,
 			&j.ErrorCount,
-			&j.ShardID.UUID,
+			&j.ShardID,
 			&j.LastError,
 		)
 

--- a/que.go
+++ b/que.go
@@ -9,7 +9,6 @@ import (
 	"github.com/weave-lab/pgx"
 	"github.com/weave-lab/pgx/pgtype"
 	"weavelab.xyz/monorail/shared/go-utilities/null"
-	"weavelab.xyz/monorail/shared/wlib/uuid"
 )
 
 // Job is a single unit of work for Que to perform.
@@ -333,7 +332,6 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 	j := Job{pool: c.pool, conn: conn}
 
 	for i := 0; i < maxLockJobAttempts; i++ {
-		var id uuid.UUID
 		err = conn.QueryRow("que_lock_job", queue).Scan(
 			&j.Queue,
 			&j.Priority,
@@ -342,11 +340,9 @@ func (c *Client) LockJob(queue string) (*Job, error) {
 			&j.Type,
 			&j.Args,
 			&j.ErrorCount,
-			&id,
+			&j.ShardID.UUID,
 			&j.LastError,
 		)
-
-		j.ShardID = null.NewUUIDUUIDDefaultAsNull(id)
 
 		if err != nil {
 			c.pool.Release(conn)

--- a/sql.go
+++ b/sql.go
@@ -54,7 +54,7 @@ WITH RECURSIVE jobs AS (
     ) AS t1
   )
 )
-SELECT queue, priority, run_at, job_id, job_class, args, error_count
+SELECT queue, priority, run_at, job_id, job_class, args, error_count, shard_id, last_error
 FROM jobs
 WHERE locked
 LIMIT 1


### PR DESCRIPTION
This is needed for DLQ requeue capabilities to work properly